### PR TITLE
Fix 404 (Not Found): skull image

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ it’s a mind-blowing experience 🤯
 
 The function is highly customisable, and we can use a black and white
 image as a **depth mask** (in this case, the [picture of a
-skull](https://github.com/DominiqueMakowski/Pyllusion/docs/img/depthmask.png)
+skull](https://raw.githubusercontent.com/RealityBending/Pyllusion/master/docs/img/depthmask.png)
 that you will see as emerging from the background), and customise the
 pattern used by providing another function (here, the `image_circles()`
 function to which we can provide additional arguments like `blackwhite`,


### PR DESCRIPTION
Just a quick link adjustment! I went through the other links in the README to make sure that they are all working as well; other links are working. I'd be grateful for any feedback if linking `raw.githubusercontent` is not the right way to go about this.

# Description

Fix for autostereogram skull image.

# Proposed Changes

Changed the [https://github.com/DominiqueMakowski/Pyllusion/docs/img/depthmask.png](https://github.com/DominiqueMakowski/Pyllusion/docs/img/depthmask.png) skull link (results in `404: Not Found`) to [https://raw.githubusercontent.com/RealityBending/Pyllusion/master/docs/img/depthmask.png](https://raw.githubusercontent.com/RealityBending/Pyllusion/master/docs/img/depthmask.png).


